### PR TITLE
fix: set baseURL to https

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -2,7 +2,7 @@ languageCode = "en-gb"
 title = "DMN developer documentation"
 theme = "hugo-material-docs"
 publishDir = "../blog-dist"
-baseURL = "http://developers.designmynight.com/"
+baseURL = "https://developers.designmynight.com/"
 metadataformat = "yaml"
 canonifyurls = false
 # Enable Google Analytics by entering your tracking id


### PR DESCRIPTION
GitHub pages are now hosted on HTTPS, so I'm updating the `baseURL` to point to `https://` so assets are loaded correctly.

fyi @willtj 