### PR TITLE
chore: add deprecation notice to Users API

### DIFF
--- a/site/content/api/users-api/index.md
+++ b/site/content/api/users-api/index.md
@@ -7,6 +7,10 @@ title: Users API
 Refer to the [API Basics](/api-basics) section to ensure you are familiar with the essentials of how to interact with the API.
 {{</note>}}
 
+{{<warning title="Deprecated">}}
+  The use of this endpoint for retrieving and updating _customer_ information is deprecated. Please use https://docs.collinsbookings.com/#tag/Customers instead.
+{{</warning>}}
+
 ## Overview
 
 The DesignMyNight Users API can be used to retrieve user information and create users, and is suitable for clients who require user information.


### PR DESCRIPTION
Adds a deprecation notice on the old Users API documentation, and links to the new Collins API Customers endpoint.

https://github.com/designmynight/dmn/issues/32185

<img width="1920" alt="image" src="https://user-images.githubusercontent.com/6871504/55732740-6d3beb80-5a14-11e9-9653-189595d11147.png">